### PR TITLE
Update Operands formatting in trace csv and add test_failure conditions for missing log and csv files

### DIFF
--- a/integration_files/SweRV_EH1/sim.py
+++ b/integration_files/SweRV_EH1/sim.py
@@ -443,6 +443,11 @@ def compare_test_run(test, idx, iss, output_dir, report):
     rtl_csv = os.path.join(rtl_dir, 'trace_core_00000000.csv')
     uvm_log = os.path.join(rtl_dir, 'sim.log')
 
+    if not os.path.exists(rtl_log):
+        with open(report, 'a') as report_fd:
+            report_fd.write('{} does not exist\n'.format(rtl_log))
+        return False
+
     try:
         # Convert the RTL log file to a trace CSV.
         process_core_sim_log(rtl_log, rtl_csv, 1)
@@ -450,6 +455,11 @@ def compare_test_run(test, idx, iss, output_dir, report):
         with open(report, 'a') as report_fd:
             report_fd.write('Log processing failed: {}\n'.format(e))
 
+        return False
+
+    if not os.path.exists(rtl_csv):
+        with open(report, 'a') as report_fd:
+            report_fd.write('{} does not exist\n'.format(rtl_csv))
         return False
 
     # Have a look at the UVM log. We should write out a message on failure or
@@ -468,11 +478,21 @@ def compare_test_run(test, idx, iss, output_dir, report):
     iss_log = os.path.join(iss_dir, '{}.{}.log'.format(test_name, idx))
     iss_csv = os.path.join(iss_dir, '{}.{}.csv'.format(test_name, idx))
 
+    if not os.path.exists(iss_log):
+        with open(report, 'a') as report_fd:
+            report_fd.write('{} does not exist\n'.format(iss_log))
+        return False
+
     if iss == "spike":
         process_spike_sim_log(iss_log, iss_csv)
     else:
         assert iss == 'ovpsim'  # (should be checked by argparse)
         process_ovpsim_sim_log(iss_log, iss_csv)
+
+    if not os.path.exists(iss_csv):
+        with open(report, 'a') as report_fd:
+            report_fd.write('{} does not exist\n'.format(iss_csv))
+        return False
 
     compare_result = \
         compare_trace_csv(rtl_csv, iss_csv, "core", iss, report,

--- a/integration_files/sim.py
+++ b/integration_files/sim.py
@@ -431,6 +431,11 @@ def compare_test_run(test, idx, iss, output_dir, report):
     rtl_csv = os.path.join(rtl_dir, 'trace_core_00000000.csv')
     uvm_log = os.path.join(rtl_dir, 'sim.log')
 
+    if not os.path.exists(rtl_log):
+        with open(report, 'a') as report_fd:
+            report_fd.write('{} does not exist\n'.format(rtl_log))
+        return False
+
     try:
         # Convert the RTL log file to a trace CSV.
         process_core_sim_log(rtl_log, rtl_csv, 1)
@@ -438,6 +443,11 @@ def compare_test_run(test, idx, iss, output_dir, report):
         with open(report, 'a') as report_fd:
             report_fd.write('Log processing failed: {}\n'.format(e))
 
+        return False
+
+    if not os.path.exists(rtl_csv):
+        with open(report, 'a') as report_fd:
+            report_fd.write('{} does not exist\n'.format(rtl_csv))
         return False
 
     # Have a look at the UVM log. We should write out a message on failure or
@@ -456,11 +466,21 @@ def compare_test_run(test, idx, iss, output_dir, report):
     iss_log = os.path.join(iss_dir, '{}.{}.log'.format(test_name, idx))
     iss_csv = os.path.join(iss_dir, '{}.{}.csv'.format(test_name, idx))
 
+    if not os.path.exists(iss_log):
+        with open(report, 'a') as report_fd:
+            report_fd.write('{} does not exist\n'.format(iss_log))
+        return False
+
     if iss == "spike":
         process_spike_sim_log(iss_log, iss_csv)
     else:
         assert iss == 'ovpsim'  # (should be checked by argparse)
         process_ovpsim_sim_log(iss_log, iss_csv)
+
+    if not os.path.exists(iss_csv):
+        with open(report, 'a') as report_fd:
+            report_fd.write('{} does not exist\n'.format(iss_csv))
+        return False
 
     compare_result = \
         compare_trace_csv(rtl_csv, iss_csv, "core", iss, report,


### PR DESCRIPTION
1- Update formatting of Operands in trace core csv
2- Update compare() in sim.py such that post_comparison fails if any of
log or csv file does not exist.