### PR TITLE
Minor Fixes Required in trace log for Extraction of Functional Coverage from SweRV Core

### DIFF
--- a/integration_files/SweRV_EH1/riscv_dv_extension/core_log_to_trace_csv.py
+++ b/integration_files/SweRV_EH1/riscv_dv_extension/core_log_to_trace_csv.py
@@ -35,7 +35,7 @@ INSTR_RE = \
 RD_RE = re.compile(r"(x(?P<rd>[1-9]\d*)=0x(?P<rd_val>[0-9a-f]+))")
 ADDR_RE = re.compile(r"(?P<imm>[\-0-9]+?)\((?P<rs1>.*)\)")
 OPERANDS_RE = re.compile(r"(?P<reg1>\w+),(?P<imm>[0-9a-fA-F-]+)\((?P<reg2>\w+)\)")
-
+ECALL_RE = re.compile(r"^\s*(?P<time>\d+)\s+(?P<cycle>\d+)\s+(?P<pc>[0-9a-f]+)\s+(?P<bin>[0-9a-f]+)\s+ecall")
 
 def _process_core_sim_log_fd(log_fd, csv_fd, full_trace=True):
     """Process core simulation log.
@@ -57,6 +57,16 @@ def _process_core_sim_log_fd(log_fd, csv_fd, full_trace=True):
 
     for line in log_fd:
         if re.search("ecall", line):
+            instr_cnt += 1
+            # Extract instruction information
+            m = ECALL_RE.search(line)
+            if m:
+                # Write the extracted instruction to a csvcol buffer file
+                trace_entry = RiscvInstructionTraceEntry()
+                trace_entry.instr_str = "ecall"
+                trace_entry.pc = m.group("pc")
+                trace_entry.binary = m.group("bin")
+                trace_csv.write_trace_entry(trace_entry)
             break
 
         # Extract instruction information

--- a/integration_files/SweRV_EH1/testbench/tb_top.sv
+++ b/integration_files/SweRV_EH1/testbench/tb_top.sv
@@ -299,13 +299,17 @@ module tb_top;
     parameter MAX_CYCLES = 10_000_000;
 
     integer fd, tp, el;
+    bit finish_ecall;
 
     always @(negedge core_clk) begin
         cycleCnt <= cycleCnt+1;
-    	if (trace_rv_i_valid_ip !== 0) begin
+    	if (finish_ecall) begin
+            $finish;
+        end
+        if (trace_rv_i_valid_ip !== 0) begin
 			if (trace_rv_i_insn_ip[31:0] == 32'h0000_0073 || trace_rv_i_insn_ip[63:32] == 32'h0000_0073) begin
 				$display ("Finishing the test on ecall",cycleCnt);
-				$finish;
+				finish_ecall = 1;
 			end
 		end
 // Test timeout monitor

--- a/integration_files/SweRV_EH1/testbench/tracer.sv
+++ b/integration_files/SweRV_EH1/testbench/tracer.sv
@@ -476,8 +476,8 @@ logic [31:0] rvfi_pc_wdata;
   function automatic void decode_i_jalr_insn(input string mnemonic);
     // JALR
     data_accessed = RS1 | RD;
-    decoded_str = $sformatf("%s\tx%0d,%0d(x%0d)", mnemonic, rvfi_rd_addr,
-        $signed({{20 {rvfi_insn[31]}}, rvfi_insn[31:20]}), rvfi_rs1_addr);
+    decoded_str = $sformatf("%s\tx%0d,x%0d,%0d", mnemonic, rvfi_rd_addr, rvfi_rs1_addr,
+        $signed({{20 {rvfi_insn[31]}}, rvfi_insn[31:20]}));
   endfunction
 
   function automatic void decode_u_insn(input string mnemonic);


### PR DESCRIPTION

1- Update core_log_to_trace_csv.py and tb_top.sv so that ecall is dumped in core trace log and csv
2- Update tracer.sv for modifying jalr format from "jalr rd, immd(rs1)" to "jalr rd, rs1, immd" in csv